### PR TITLE
fix(server): Changed the Timeout error message to make it easier to u…

### DIFF
--- a/util/grpc/errors.go
+++ b/util/grpc/errors.go
@@ -11,7 +11,10 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func rewrapError(err error, code codes.Code) error {
+func rewrapError(err error, code codes.Code, msg ...string) error {
+	if len(msg) > 0 {
+		return status.Errorf(code, "%s", msg[0])
+	}
 	return status.Errorf(code, err.Error())
 }
 
@@ -83,7 +86,7 @@ func kubeErrToGRPC(err error) error {
 	case apierr.IsForbidden(err):
 		err = rewrapError(err, codes.PermissionDenied)
 	case apierr.IsTimeout(err):
-		err = rewrapError(err, codes.DeadlineExceeded)
+		err = rewrapError(err, codes.DeadlineExceeded, "Command timed out before the specified conditions were met")
 	case apierr.IsServerTimeout(err):
 		err = rewrapError(err, codes.Unavailable)
 	case apierr.IsConflict(err):


### PR DESCRIPTION
…nderstand (#14705)

- Closes the Issue #14705 
- The command `argocd app wait --timeout` was printing the raw error message, which doesn't describe the issue properly, this PR modifies the error message to a friendly one.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
